### PR TITLE
Maccel sens change support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you have a 1440p monitor, add this argument to the clone command `-b 1440`
 - Use the `normal_kb` table if you want any remaps to stay in chat mode, or leave it empty
 
 6. Miscellaneous
-- If you setup boat eye as per the [guide](https://its-saanvi.github.io/linux-mcsr/minecraft/wayland/boat-eye.html), set your waywall sens coefficients here
+- If you setup boat eye as per the [guide](https://its-saanvi.github.io/linux-mcsr/minecraft/wayland/boat-eye.html), set your waywall sens coefficients here, if you have raw input set to on in your minecraft configuration, set the raw_input setting in input.lua to on (this alternative method requires [maccel](maccel.org) to be installed)
 - If you wish to use Char's [Resize Animations](https://github.com/char3210/resize_animation/blob/main/resize_animation_waywall.py), set `enable_resize_animations` to true and follow the steps to setup OBS at the top of the python script.
 
 

--- a/init.lua
+++ b/init.lua
@@ -72,7 +72,7 @@ local cfg = {
 
 
     -- ==== MISC ====
-    sens_change = { enabled = false, normal = 1.0, tall = 0.1 }, -- make sure raw input is off
+    sens_change = { enabled = false, normal = 1.0, tall = 0.1, raw_input = false }, -- if you have raw input on, set this option to true
     enable_resize_animations = false,
 
 }

--- a/main.lua
+++ b/main.lua
@@ -77,6 +77,13 @@ return function(cfg, remaps)
         handle:close()
         return result ~= nil
     end
+    function set_sens (sens)
+        if cfg.sens_change.raw_input then
+            waywall.exec("maccel set param sens_mult " .. sens)
+        else
+            waywall.set_sensitivity(sens)
+        end
+    end
 
     -- ==== MIRRORS ====
     -- colors
@@ -270,24 +277,24 @@ return function(cfg, remaps)
     local thin_enable = function()
         thin_active = true
         if cfg.sens_change.enabled then
-            waywall.set_sensitivity(cfg.sens_change.normal)
+            set_sens(cfg.sens_change.normal)
         end
     end
     local tall_enable = function()
         if cfg.sens_change.enabled and not thin_active then
-            waywall.set_sensitivity(cfg.sens_change.tall)
+            set_sens(cfg.sens_change.tall)
         end
         thin_active = false
     end
     local wide_enable = function()
         if cfg.sens_change.enabled then
-            waywall.set_sensitivity(cfg.sens_change.normal)
+            set_sens(cfg.sens_change.normal)
         end
         thin_active = false
     end
     local res_disable = function()
         if cfg.sens_change.enabled then
-            waywall.set_sensitivity(cfg.sens_change.normal)
+            set_sens(cfg.sens_change.normal)
         end
         thin_active = false
     end


### PR DESCRIPTION
An alternate way to change sens for going in tall mode. This option uses `maccel` and unlike `waywall.set_sensitivity` works even with raw input toggled to on